### PR TITLE
Implement rainbow options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "quantrs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "approx",
  "criterion",

--- a/Cargo.lock.MSRV
+++ b/Cargo.lock.MSRV
@@ -206,14 +206,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ dependencies = [
 
 [[package]]
 name = "quantrs"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "approx",
  "criterion",
@@ -452,6 +452,12 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -510,7 +516,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -726,9 +732,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -895,9 +901,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "quantrs"
-version = "0.1.3"
-authors = ["Carlo Bortolan"]
+version = "0.1.4"
+authors = ["Carlo Bortolan <carlobortolan@gmail.com>"]
 description = " A tiny Rust library for quantitative finance"
 license = "MIT"
-# keywords = ["quantitative", "statistics", "finance", "options", "timeseries"]
-# categories = ["science"]
+# license = "MIT OR Apache-2.0"
+# keywords = ["quantitative", "statistics", "finance", "options", "pricing"]
+# categories = ["finance", "simulation", "mathematics"]
 repository = "https://github.com/carlobortolan/quantrs"
 documentation = "https://docs.rs/quantrs"
 homepage = "https://github.com/carlobortolan/quantrs"

--- a/OUTLOOK.md
+++ b/OUTLOOK.md
@@ -173,6 +173,15 @@ This document outlines the planned features and improvements for the `quantrs` l
   - [ ] Minimum variance
   - [ ] Maximum diversification
 
+### Rates Space
+- [ ] Yield curve modelling, parameterization, linear swap pricing/risk
+- [ ] Inflation modelling and swap/linker pricing
+- [ ] Vanilla swaptions, SABR, YCSO, mid-curve swaptions, CMS, Bermudans
+- [ ] Listed rates futures and options
+- [ ] Bond/Repo Pricing
+- [ ] MBS modelling and integration into OTC risk
+- [ ] Risk based PnL across Fixed Income assets
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE.md](LICENSE.md) file for details.

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ For now quantrs only supports options pricing of vanilla and exotic options with
 | American                    | ❌              | ❌       | ✅           | ❌ (L. Sq.)  | ⏳            | ❌     |
 | Bermudan                    | ❌              | ❌       | ⏳           | ❌ (L. Sq.)  | ❌ (complex)  | ❌     |
 | ¹Basket                     | ⏳ (∀component) | ❌       | ⏳ (approx.) | ⏳           | ❌            | ❌     |
-| ¹Rainbow                    | ✅ (∀component) | ❌       | ⏳ (approx.) | ⏳           | ❌            | ❌     |
+| ¹Rainbow                    | ✅ (∀component) | ❌       | ✅           | ✅           | ❌            | ❌     |
 | ²Barrier                    | ❌ (mod. BSM)   | ❌       | ⏳           | ⏳           | ⏳            | ⏳     |
 | ²Double Barrier             | ❌ (mod. BSM)   | ❌       | ⏳           | ⏳           | ❌ (complex)  | ⏳     |
 | ²Asian (fixed strike)       | ❌ (mod. BSM)   | ❌       | ❌           | ✅           | ⏳            | ⏳     |
 | ²Asian (floating strike)    | ❌ (mod. BSM)   | ❌       | ❌           | ✅           | ⏳            | ⏳     |
 | ²Lookback (fixed strike)    | ⏳              | ❌       | ❌           | ⏳           | ⏳            | ⏳     |
 | ²Lookback (floating strike) | ⏳              | ❌       | ❌           | ⏳           | ⏳            | ⏳     |
-| ²Binary Cash-or-Nothing     | ✅              | ⏳       | ⏳           | ✅           | ❌ (mod. PDE) | ⏳     |
-| ²Binary Asset-or-Nothing    | ✅              | ⏳       | ⏳           | ✅           | ❌ (mod. PDE) | ⏳     |
+| ²Binary Cash-or-Nothing     | ✅              | ⏳       | ✅           | ✅           | ❌ (mod. PDE) | ⏳     |
+| ²Binary Asset-or-Nothing    | ✅              | ⏳       | ✅           | ✅           | ❌ (mod. PDE) | ⏳     |
 | Greeks (Δ, ν, Θ, ρ, Γ)      | ✅              | ⏳       | ⏳           | ❌           | ❌            | ❌     |
 | Implied Volatility          | ✅              | ⏳       | ⏳           | ❌           | ❌            | ❌     |
 

--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Compared to other popular options pricing libraries, quantrs is _significantly_ 
 | ------------------------------------------------------ | ------------------------ | -------------------------- | ----------------------- | ------------------------- |
 | quantrs                                                | 0.0971                   | 0.0970                     | 0.0007                  | 10,142,000                |
 | [QuantLib](https://www.quantlib.org) (cpp)             | n.a.                     | n.a.                       | n.a.                    | n.a.                      |
-| [QuantLib](https://pypi.org/project/QuantLib) (py)     | 2.8551                   | 2.8630 (29x slower)        | 0.9391                  | 350,250                   |
-| [py_vollib](https://github.com/vollib/py_vollib)       | 10.9959                  | 10.8950 (110x slower)      | 1.1398                  | 90,943                    |
+| [QuantLib](https://pypi.org/project/QuantLib) (py)     | 2.8551                   | 2.8630                     | 0.9391                  | 350,250                   |
+| [py_vollib](https://github.com/vollib/py_vollib)       | 10.9959                  | 10.8950                    | 1.1398                  | 90,943                    |
 | [Q-Fin](https://github.com/romanmichaelpaolucci/Q-Fin) | 0.2622                   | 0.2603                     | 0.0356                  | 3,813,700                 |
 | [RustQuant](https://github.com/avhz/RustQuant)         | 1.4777                   | 1.4750                     | 0.0237                  | 676,727                   |
 
@@ -87,7 +87,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-quantrs = "0.1.3"
+quantrs = "0.1.4"
 ```
 
 Now if you want to e.g., model binary call options using the Black-Scholes model, you can:

--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ For now quantrs only supports options pricing of vanilla and exotic options with
 | American                    | ❌              | ❌       | ✅           | ❌ (L. Sq.)  | ⏳            | ❌     |
 | Bermudan                    | ❌              | ❌       | ⏳           | ❌ (L. Sq.)  | ❌ (complex)  | ❌     |
 | ¹Basket                     | ⏳ (∀component) | ❌       | ⏳ (approx.) | ⏳           | ❌            | ❌     |
-| ¹Rainbow                    | ⏳ (∀component) | ❌       | ⏳ (approx.) | ⏳           | ❌            | ❌     |
+| ¹Rainbow                    | ✅ (∀component) | ❌       | ⏳ (approx.) | ⏳           | ❌            | ❌     |
 | ²Barrier                    | ❌ (mod. BSM)   | ❌       | ⏳           | ⏳           | ⏳            | ⏳     |
 | ²Double Barrier             | ❌ (mod. BSM)   | ❌       | ⏳           | ⏳           | ❌ (complex)  | ⏳     |
 | ²Asian (fixed strike)       | ❌ (mod. BSM)   | ❌       | ❌           | ✅           | ⏳            | ⏳     |
-| ²Asian (floating strike)    | ❌ (mod. BSM)   | ❌       | ❌           | ✅ (flaky)   | ⏳            | ⏳     |
+| ²Asian (floating strike)    | ❌ (mod. BSM)   | ❌       | ❌           | ✅           | ⏳            | ⏳     |
 | ²Lookback (fixed strike)    | ⏳              | ❌       | ❌           | ⏳           | ⏳            | ⏳     |
 | ²Lookback (floating strike) | ⏳              | ❌       | ❌           | ⏳           | ⏳            | ⏳     |
 | ²Binary Cash-or-Nothing     | ✅              | ⏳       | ⏳           | ✅           | ❌ (mod. PDE) | ⏳     |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![docs.rs][docsrs-badge]][docs-url]
 [![codecov-quantrs][codecov-badge]][codecov-url]
 ![Crates.io MSRV][crates-msrv-badge]
+![Crates.io downloads][crates-download-badge]
 
 [actions-test-badge]: https://github.com/carlobortolan/quantrs/actions/workflows/ci.yml/badge.svg
 [crates-badge]: https://img.shields.io/crates/v/quantrs.svg
@@ -16,6 +17,7 @@
 [codecov-badge]: https://codecov.io/gh/carlobortolan/quantrs/graph/badge.svg?token=NJ4HW3OQFY
 [codecov-url]: https://codecov.io/gh/carlobortolan/quantrs
 [crates-msrv-badge]: https://img.shields.io/crates/msrv/quantrs
+[crates-download-badge]: https://img.shields.io/crates/d/quantrs
 
 Quantrs is a tiny quantitative finance library for Rust.
 It is designed to be as intuitive and easy to use as possible so that you can work with derivatives without the need to write complex code or have a PhD in reading quantlib documentation.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please check out the documentation [here][docs-url].
 
 ### Options Pricing
 
-For now quantrs only supports options pricing of vanilla and exotic options with continuous dividends yields.
+For now quantrs only supports options pricing of vanilla and various exotic options.
 
 <details>
 <summary><i>Click to see supported models</i></summary>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For now quantrs only supports options pricing of vanilla and various exotic opti
 | ²Lookback (floating strike) | ⏳              | ❌       | ❌           | ⏳           | ⏳            | ⏳     |
 | ²Binary Cash-or-Nothing     | ✅              | ⏳       | ✅           | ✅           | ❌ (mod. PDE) | ⏳     |
 | ²Binary Asset-or-Nothing    | ✅              | ⏳       | ✅           | ✅           | ❌ (mod. PDE) | ⏳     |
-| Greeks (Δ, ν, Θ, ρ, Γ)      | ✅              | ⏳       | ⏳           | ❌           | ❌            | ❌     |
+| Greeks (Δ,ν,Θ,ρ,Γ)          | ✅              | ⏳       | ⏳           | ❌           | ❌            | ❌     |
 | Implied Volatility          | ✅              | ⏳       | ⏳           | ❌           | ❌            | ❌     |
 
 > ¹ _"Exotic" options with standard exercise style; only differ in their payoff value_\

--- a/examples/options_pricing.rs
+++ b/examples/options_pricing.rs
@@ -7,13 +7,13 @@ use quantrs::options::{
 };
 
 fn main() {
-    // example_from_readme();
-    // example_black_scholes();
-    // example_binomial_tree();
-    // example_greeks();
-    // example_monte_carlo();
+    example_from_readme();
+    example_black_scholes();
+    example_binomial_tree();
+    example_greeks();
+    example_monte_carlo();
     rainbow_option_example();
-    // example_asian();
+    example_asian();
 }
 
 fn example_black_scholes() {

--- a/examples/options_pricing.rs
+++ b/examples/options_pricing.rs
@@ -167,53 +167,72 @@ fn rainbow_option_example() {
     let put_on_max = RainbowOption::put_on_max(instrument.clone(), 120.0);
     let put_on_min = RainbowOption::put_on_min(instrument.clone(), 105.0);
 
-    println!("Best-Of Payoff: {}", best_of.payoff());
-    println!("Worst-Of Payoff: {}", worst_of.payoff()); // should be 86.0
-    println!("Call-On-Max Payoff: {}", call_on_max.payoff()); // should be 10.0
-    println!("Call-On-Min Payoff: {}", call_on_min.payoff()); // should be 6.0
-    println!("Put-On-Max Payoff: {}", put_on_max.payoff()); // should be 5.0
-    println!("Put-On-Min Payoff: {}", put_on_min.payoff()); // should be 19.0
+    println!(
+        "Best-Of Payoff: {}, {:?}",
+        best_of.payoff(None),
+        best_of.instrument()
+    ); // should be 115.0
+    println!(
+        "Worst-Of Payoff: {}, {:?}",
+        worst_of.payoff(None),
+        worst_of.instrument()
+    ); // should be 86.0
+       //    println!("Call-On-Max Payoff: {}", call_on_max.payoff(None)); // should be 10.0
+       //    println!("Call-On-Min Payoff: {}", call_on_min.payoff(None)); // should be 6.0
+       //    println!("Put-On-Max Payoff: {}", put_on_max.payoff(None)); // should be 5.0
+       //    println!("Put-On-Min Payoff: {}", put_on_min.payoff(None)); // should be 19.0
 
     let bin_max = BinaryOption::asset_or_nothing(asset1.clone(), 105.0, OptionType::Call);
-    let bin_min = BinaryOption::asset_or_nothing(asset1.clone(), 105.0, OptionType::Put);
+    let bin_min = BinaryOption::asset_or_nothing(asset3.clone(), 105.0, OptionType::Put);
     let eur_call_max = EuropeanOption::new(asset1.clone(), 105.0, OptionType::Call);
     let eur_call_min = EuropeanOption::new(asset3.clone(), 80.0, OptionType::Call);
     let eur_put_max = EuropeanOption::new(asset1.clone(), 120.0, OptionType::Put);
     let eur_put_min = EuropeanOption::new(asset3.clone(), 105.0, OptionType::Put);
 
-    let model = MonteCarloModel::arithmetic(1.0, 0.05, 0.2, 10_000, 252);
-    // let model = BlackScholesModel::new(1.0, 0.05, 0.2);
-    // println!(
-    //     "Best-Of Price: {}, should be: {}",
-    //     model.price(&best_of),
-    //     model.price(&bin_max)
-    // );
-    // println!(
-    //     "Worst-Of Price: {}, should be: {}",
-    //     model.price(&worst_of),
-    //     model.price(&bin_min)
-    // );
     println!(
-        "Call-On-Max Price: {}, should be: {}",
-        model.price(&call_on_max),
-        model.price(&eur_call_max)
-    );
+        "Bin-Max Payoff: {}, {:?}",
+        bin_max.payoff(None),
+        bin_max.instrument()
+    ); // should be 10.0
     println!(
-        "Call-On-Min Price: {}, should be: {}",
-        model.price(&call_on_min),
-        model.price(&eur_call_min)
-    );
-    println!(
-        "Put-On-Max Price: {}, should be: {}",
-        model.price(&put_on_max),
-        model.price(&eur_put_max)
-    );
-    println!(
-        "Put-On-Min Price: {}, should be: {}",
-        model.price(&put_on_min),
-        model.price(&eur_put_min)
-    );
+        "Bin-Min Payoff: {}, {:?}",
+        bin_min.payoff(None),
+        bin_min.instrument()
+    ); // should be 6.0
 
+    let model = MonteCarloModel::arithmetic(1.0, 0.05, 0.2, 10, 252);
+    //let model = BlackScholesModel::new(1.0, 0.05, 0.2);
+    println!(
+        "Best-Of Price: {}, should be: {}",
+        model.price(&best_of),
+        model.price(&bin_max)
+    );
+    println!(
+        "Worst-Of Price: {}, should be: {}",
+        model.price(&worst_of),
+        model.price(&bin_min)
+    );
+    //println!(
+    //    "Call-On-Max Price: {}, should be: {}",
+    //    model.price(&call_on_max),
+    //    model.price(&eur_call_max)
+    //);
+    //println!(
+    //    "Call-On-Min Price: {}, should be: {}",
+    //    model.price(&call_on_min),
+    //    model.price(&eur_call_min)
+    //);
+    //println!(
+    //    "Put-On-Max Price: {}, should be: {}",
+    //    model.price(&put_on_max),
+    //    model.price(&eur_put_max)
+    //);
+    //println!(
+    //    "Put-On-Min Price: {}, should be: {}",
+    //    model.price(&put_on_min),
+    //    model.price(&eur_put_min)
+    //);
+    //
     // Call-On-Max Price: 18.149769825601027, should be: 18.149769825601027
     // Call-On-Min Price: 12.572331070072991, should be: 12.572331070072991
     // Put-On-Max Price: 8.706509687477691, should be: 8.706509687477691

--- a/examples/options_pricing.rs
+++ b/examples/options_pricing.rs
@@ -150,89 +150,97 @@ fn example_from_readme() {
 }
 
 fn rainbow_option_example() {
-    let asset1 = Instrument::new().with_spot(115.0);
-    let asset2 = Instrument::new().with_spot(104.0);
-    let asset3 = Instrument::new().with_spot(86.0);
+    let q = 0.0;
+
+    let asset1 = Instrument::new()
+        .with_spot(115.0)
+        .with_continuous_dividend_yield(q);
+    let asset2 = Instrument::new()
+        .with_spot(104.0)
+        .with_continuous_dividend_yield(q);
+    let asset3 = Instrument::new()
+        .with_spot(86.0)
+        .with_continuous_dividend_yield(q);
 
     // Pays 50% of the best return (at maturity), 30% of the second best and 20% of the third best
     let _weights = [0.5, 0.3, 0.2];
 
-    let instrument =
-        Instrument::new().with_assets(vec![(asset1.clone()), (asset2.clone()), (asset3.clone())]);
+    let instrument = Instrument::new()
+        .with_assets(vec![(asset1.clone()), (asset2.clone()), (asset3.clone())])
+        .with_continuous_dividend_yield(q);
 
     let best_of = RainbowOption::best_of(instrument.clone(), 105.0);
     let worst_of = RainbowOption::worst_of(instrument.clone(), 105.0);
+    let call_on_avg = RainbowOption::call_on_avg(instrument.clone(), 100.0);
+    let put_on_avg = RainbowOption::put_on_avg(instrument.clone(), 110.0);
+    let all_itm = RainbowOption::all_itm(instrument.clone(), 105.0);
+    let all_otm = RainbowOption::all_otm(instrument.clone(), 105.0);
     let call_on_max = RainbowOption::call_on_max(instrument.clone(), 105.0);
     let call_on_min = RainbowOption::call_on_min(instrument.clone(), 80.0);
     let put_on_max = RainbowOption::put_on_max(instrument.clone(), 120.0);
     let put_on_min = RainbowOption::put_on_min(instrument.clone(), 105.0);
 
-    println!(
-        "Best-Of Payoff: {}, {:?}",
-        best_of.payoff(None),
-        best_of.instrument()
-    ); // should be 115.0
-    println!(
-        "Worst-Of Payoff: {}, {:?}",
-        worst_of.payoff(None),
-        worst_of.instrument()
-    ); // should be 86.0
-       //    println!("Call-On-Max Payoff: {}", call_on_max.payoff(None)); // should be 10.0
-       //    println!("Call-On-Min Payoff: {}", call_on_min.payoff(None)); // should be 6.0
-       //    println!("Put-On-Max Payoff: {}", put_on_max.payoff(None)); // should be 5.0
-       //    println!("Put-On-Min Payoff: {}", put_on_min.payoff(None)); // should be 19.0
+    println!("Best-Of Payoff: {}", best_of.payoff(None)); // should be 115.0
+    println!("Worst-Of Payoff: {}", worst_of.payoff(None)); // should be 86.0
+    println!("Call-On-Avg Payoff: {}", call_on_avg.payoff(None)); // should be 1.6
+    println!("Put-On-Avg Payoff: {}", put_on_avg.payoff(None)); // should be 8.3
+    println!("All ITM Payoff: {}", all_itm.payoff(None)); // should be 0.0
+    println!("All OTM Payoff: {}", all_otm.payoff(None)); // should be 0.0
+    println!("Call-On-Max Payoff: {}", call_on_max.payoff(None)); // should be 10.0
+    println!("Call-On-Min Payoff: {}", call_on_min.payoff(None)); // should be 6.0
+    println!("Put-On-Max Payoff: {}", put_on_max.payoff(None)); // should be 5.0
+    println!("Put-On-Min Payoff: {}", put_on_min.payoff(None)); // should be 19.0
 
-    let bin_max = BinaryOption::asset_or_nothing(asset1.clone(), 105.0, OptionType::Call);
-    let bin_min = BinaryOption::asset_or_nothing(asset3.clone(), 105.0, OptionType::Put);
     let eur_call_max = EuropeanOption::new(asset1.clone(), 105.0, OptionType::Call);
     let eur_call_min = EuropeanOption::new(asset3.clone(), 80.0, OptionType::Call);
     let eur_put_max = EuropeanOption::new(asset1.clone(), 120.0, OptionType::Put);
     let eur_put_min = EuropeanOption::new(asset3.clone(), 105.0, OptionType::Put);
 
-    println!(
-        "Bin-Max Payoff: {}, {:?}",
-        bin_max.payoff(None),
-        bin_max.instrument()
-    ); // should be 10.0
-    println!(
-        "Bin-Min Payoff: {}, {:?}",
-        bin_min.payoff(None),
-        bin_min.instrument()
-    ); // should be 6.0
+    // let model = MonteCarloModel::arithmetic(1.0, 0.05, 0.2, 1_000, 252);
+    let model = BinomialTreeModel::new(1.0, 0.05, 0.2, 100);
+    // let model = BlackScholesModel::new(1.0, 0.05, 0.2);
 
-    let model = MonteCarloModel::arithmetic(1.0, 0.05, 0.2, 10, 252);
-    //let model = BlackScholesModel::new(1.0, 0.05, 0.2);
     println!(
         "Best-Of Price: {}, should be: {}",
         model.price(&best_of),
-        model.price(&bin_max)
+        118.03716196015654
     );
     println!(
         "Worst-Of Price: {}, should be: {}",
         model.price(&worst_of),
-        model.price(&bin_min)
+        83.58825958790867
     );
-    //println!(
-    //    "Call-On-Max Price: {}, should be: {}",
-    //    model.price(&call_on_max),
-    //    model.price(&eur_call_max)
-    //);
-    //println!(
-    //    "Call-On-Min Price: {}, should be: {}",
-    //    model.price(&call_on_min),
-    //    model.price(&eur_call_min)
-    //);
-    //println!(
-    //    "Put-On-Max Price: {}, should be: {}",
-    //    model.price(&put_on_max),
-    //    model.price(&eur_put_max)
-    //);
-    //println!(
-    //    "Put-On-Min Price: {}, should be: {}",
-    //    model.price(&put_on_min),
-    //    model.price(&eur_put_min)
-    //);
-    //
+    println!(
+        "Call-On-Avg Price: {}, should be: {}",
+        model.price(&call_on_avg),
+        11.55384829911662
+    );
+    println!(
+        "Put-On-Avg Price: {}, should be: {}",
+        model.price(&put_on_avg),
+        9.76633986600689
+    );
+    println!(
+        "Call-On-Max Price: {}, should be: {}",
+        model.price(&call_on_max),
+        model.price(&eur_call_max)
+    );
+    println!(
+        "Call-On-Min Price: {}, should be: {}",
+        model.price(&call_on_min),
+        model.price(&eur_call_min)
+    );
+    println!(
+        "Put-On-Max Price: {}, should be: {}",
+        model.price(&put_on_max),
+        model.price(&eur_put_max)
+    );
+    println!(
+        "Put-On-Min Price: {}, should be: {}",
+        model.price(&put_on_min),
+        model.price(&eur_put_min)
+    );
+
     // Call-On-Max Price: 18.149769825601027, should be: 18.149769825601027
     // Call-On-Min Price: 12.572331070072991, should be: 12.572331070072991
     // Put-On-Max Price: 8.706509687477691, should be: 8.706509687477691

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,19 @@
 //! The goal is to provide library for pricing options, calculating greeks, and performing basic risk analysis without the need to write complex code or have a PhD in reading quantlib documentation.
 //! The library is still in the early stages of development, and many features are not yet implemented.
 //!
-//! There are no benchmarks yet, but it is expected to be faster than FinancePy, optlib, QuantScale and easier to use than RustQuant or QuantLib.
+//! Compared to other popular options pricing libraries, quantrs is _significantly_ faster:
+//! - **29x faster** than `QuantLib` (python bindings)
+//! - **113x faster** than `py_vollib`
+//! - **15x faster** than `RustQuant`
+//! - **2.7x faster** than `Q-Fin`
+//!
+//! _You can find the benchmarks at [quantrs.pages.dev/report](https://quantrs.pages.dev/report/)_.
 //!
 //! ## Options Pricing
 //!
 //! For now quantrs only supports options pricing. The following features are available:
 //!
-//! - Option types: European, American, Binary Cash-or-Nothing, Binary Asset-or-Nothing
+//! - Option types: European, American, Asian, Rainbow, Binary Cash-or-Nothing, Binary Asset-or-Nothing
 //! - Option pricing: Black-Scholes, Binomial Tree, Monte Carlo Simulation
 //! - Greeks: Delta, Gamma, Theta, Vega, Rho
 //! - Implied volatility

--- a/src/options/instrument.rs
+++ b/src/options/instrument.rs
@@ -152,7 +152,7 @@ impl Instrument {
         if !self.sorted {
             panic!("Assets are not sorted");
         }
-        &self.assets.get(self.assets.len() - 1).unwrap().0
+        &self.assets.last().unwrap().0
     }
 
     /// Simulate random asset prices (Euler method)

--- a/src/options/instrument.rs
+++ b/src/options/instrument.rs
@@ -152,7 +152,7 @@ impl Instrument {
         if !self.sorted {
             panic!("Assets are not sorted");
         }
-        &self.assets[self.assets.len() - 1].0
+        &self.assets.get(self.assets.len() - 1).unwrap().0
     }
 
     /// Simulate random asset prices (Euler method)

--- a/src/options/instrument.rs
+++ b/src/options/instrument.rs
@@ -102,6 +102,10 @@ impl Instrument {
 
     /// Set the assets of the instrument.
     pub fn with_assets(mut self, assets: Vec<Instrument>) -> Self {
+        if assets.is_empty() {
+            return self;
+        }
+
         let weight = 1.0 / assets.len() as f64;
         self.assets = assets.iter().map(|asset| (asset.clone(), weight)).collect();
         self.spot = self.assets.iter().map(|(a, w)| a.spot * w).sum::<f64>();
@@ -111,6 +115,10 @@ impl Instrument {
 
     /// Set the assets and their weights of the instrument.
     pub fn with_weighted_assets(mut self, assets: Vec<(Instrument, f64)>) -> Self {
+        if assets.is_empty() {
+            return self;
+        }
+
         self.assets = assets;
         self.sort_assets_by_performance();
         self
@@ -126,6 +134,9 @@ impl Instrument {
 
     /// Get best performing asset.
     pub fn best_performer(&self) -> &Instrument {
+        if self.assets.is_empty() {
+            return self;
+        }
         if !self.sorted {
             panic!("Assets are not sorted");
         }
@@ -134,6 +145,10 @@ impl Instrument {
 
     /// Get worst performing asset.
     pub fn worst_performer(&self) -> &Instrument {
+        if self.assets.is_empty() {
+            return self;
+        }
+
         if !self.sorted {
             panic!("Assets are not sorted");
         }

--- a/src/options/instrument.rs
+++ b/src/options/instrument.rs
@@ -82,6 +82,9 @@ impl Instrument {
     /// Set the continuous dividend yield of the instrument.
     pub fn with_continuous_dividend_yield(mut self, yield_: f64) -> Self {
         self.continuous_dividend_yield = yield_;
+        self.assets.iter_mut().for_each(|(a, _)| {
+            a.continuous_dividend_yield = yield_;
+        });
         self
     }
 
@@ -101,6 +104,7 @@ impl Instrument {
     pub fn with_assets(mut self, assets: Vec<Instrument>) -> Self {
         let weight = 1.0 / assets.len() as f64;
         self.assets = assets.iter().map(|asset| (asset.clone(), weight)).collect();
+        self.spot = self.assets.iter().map(|(a, w)| a.spot * w).sum::<f64>();
         self.sort_assets_by_performance();
         self
     }
@@ -116,6 +120,7 @@ impl Instrument {
     pub fn sort_assets_by_performance(&mut self) {
         self.assets
             .sort_by(|a, b| b.0.spot.partial_cmp(&a.0.spot).unwrap());
+        self.spot = self.assets.iter().map(|(a, w)| a.spot * w).sum::<f64>();
         self.sorted = true;
     }
 

--- a/src/options/models/binomial_tree.rs
+++ b/src/options/models/binomial_tree.rs
@@ -107,7 +107,11 @@ impl OptionPricing for BinomialTreeModel {
         let d = 1.0 / u;
 
         // Risk-neutral probability of an upward movement for a call option
-        let p = ((self.risk_free_rate * dt).exp() - d) / (u - d);
+        // let p = ((self.risk_free_rate * dt).exp() - d) / (u - d);
+        let p = (((self.risk_free_rate - option.instrument().continuous_dividend_yield) * dt)
+            .exp()
+            - d)
+            / (u - d);
 
         // Discount factor for each step
         let discount_factor = (-self.risk_free_rate * dt).exp();

--- a/src/options/models/monte_carlo.rs
+++ b/src/options/models/monte_carlo.rs
@@ -191,7 +191,7 @@ impl MonteCarloModel {
     }
 
     fn price_rainbow<T: Option>(&self, option: &T) -> f64 {
-        unimplemented!()
+        self.simulate_price_paths(option)
     }
 
     fn price_barrier<T: Option>(&self, option: &T) -> f64 {

--- a/src/options/types.rs
+++ b/src/options/types.rs
@@ -3,6 +3,7 @@
 //! ## References
 //!
 //! - [Wikipedia: Option Style](https://en.wikipedia.org/wiki/Option_style)
+
 pub mod american_option;
 pub mod asian_option;
 pub mod binary_option;
@@ -61,6 +62,10 @@ pub enum RainbowType {
     CallOnMin,
     PutOnMax,
     PutOnMin,
+    CallOnAvg,
+    PutOnAvg,
+    AllITM,
+    AllOTM,
 }
 
 /// Enum representing the type of a Binary option.

--- a/src/options/types/rainbow_option.rs
+++ b/src/options/types/rainbow_option.rs
@@ -22,14 +22,14 @@
 //! - [Investopedia - Rainbow option](https://www.investopedia.com/terms/r/rainbowoption.asp)
 //!
 //! ## Example
-//! 
+//!
 //! ```
 //! use quantrs::options::{Instrument, Option, RainbowOption, OptionType, RainbowType};
-//! 
+//!
 //! let asset1 = Instrument::new().with_spot(100.0);
 //! let asset2 = Instrument::new().with_spot(110.0);
 //! let asset3 = Instrument::new().with_spot(90.0);
-//! 
+//!
 //! let instrument = Instrument::new()
 //!    .with_assets(vec![(asset1.clone()), (asset2.clone()), (asset3.clone())]);
 //!    
@@ -43,7 +43,7 @@
 //! let call_on_min = RainbowOption::call_on_min(instrument.clone(), 80.0);
 //! let put_on_max = RainbowOption::put_on_max(instrument.clone(), 120.0);
 //! let put_on_min = RainbowOption::put_on_min(instrument.clone(), 105.0);
-//! 
+//!
 //! println!("Best-Of Payoff: {}", best_of.payoff(None)); // should be 115.0
 //! println!("Worst-Of Payoff: {}", worst_of.payoff(None)); // should be 86.0
 //! println!("Call-On-Avg Payoff: {}", call_on_avg.payoff(None)); // should be 1.6

--- a/src/options/types/rainbow_option.rs
+++ b/src/options/types/rainbow_option.rs
@@ -1,4 +1,60 @@
 //! Module for Rainbow option type.
+//!
+//! A Rainbow option is a type of option whose payoff depends on the performance of multiple underlying assets.
+//! The payoff of a Rainbow option can be based on the best or worst performing asset, the average performance of the assets, or other combinations.
+//!
+//! ## Rainbow Types
+//! - `BestOf`: Pays the maximum return of the underlying assets.
+//! - `WorstOf`: Pays the minimum return of the underlying assets.
+//! - `CallOnMax`: Pays the difference between the maximum return and the strike price.
+//! - `CallOnMin`: Pays the difference between the minimum return and the strike price.
+//! - `PutOnMax`: Pays the difference between the strike price and the maximum return.
+//! - `PutOnMin`: Pays the difference between the strike price and the minimum return.
+//! - `CallOnAvg`: Pays the difference between the average return and the strike price.
+//! - `PutOnAvg`: Pays the difference between the strike price and the average return.
+//! - `AllITM`: Pays the sum of the returns if all assets are in-the-money.
+//! - `AllOTM`: Pays the sum of the returns if all assets are out-of-the-money.
+//!
+//! ## References
+//!
+//! - [Wikipedia - Rainbow option](https://en.wikipedia.org/wiki/Rainbow_option)
+//! - [FiNcyclopedia](https://fincyclopedia.net/derivatives/r/rainbow-option)
+//! - [Investopedia - Rainbow option](https://www.investopedia.com/terms/r/rainbowoption.asp)
+//!
+//! ## Example
+//! 
+//! ```
+//! use quantrs::options::{Instrument, Option, RainbowOption, OptionType, RainbowType};
+//! 
+//! let asset1 = Instrument::new().with_spot(100.0);
+//! let asset2 = Instrument::new().with_spot(110.0);
+//! let asset3 = Instrument::new().with_spot(90.0);
+//! 
+//! let instrument = Instrument::new()
+//!    .with_assets(vec![(asset1.clone()), (asset2.clone()), (asset3.clone())]);
+//!    
+//! let best_of = RainbowOption::best_of(instrument.clone(), 105.0);
+//! let worst_of = RainbowOption::worst_of(instrument.clone(), 105.0);
+//! let call_on_avg = RainbowOption::call_on_avg(instrument.clone(), 100.0);
+//! let put_on_avg = RainbowOption::put_on_avg(instrument.clone(), 110.0);
+//! let all_itm = RainbowOption::all_itm(instrument.clone(), 105.0);
+//! let all_otm = RainbowOption::all_otm(instrument.clone(), 105.0);
+//! let call_on_max = RainbowOption::call_on_max(instrument.clone(), 105.0);
+//! let call_on_min = RainbowOption::call_on_min(instrument.clone(), 80.0);
+//! let put_on_max = RainbowOption::put_on_max(instrument.clone(), 120.0);
+//! let put_on_min = RainbowOption::put_on_min(instrument.clone(), 105.0);
+//! 
+//! println!("Best-Of Payoff: {}", best_of.payoff(None)); // should be 115.0
+//! println!("Worst-Of Payoff: {}", worst_of.payoff(None)); // should be 86.0
+//! println!("Call-On-Avg Payoff: {}", call_on_avg.payoff(None)); // should be 1.6
+//! println!("Put-On-Avg Payoff: {}", put_on_avg.payoff(None)); // should be 8.3
+//! println!("All ITM Payoff: {}", all_itm.payoff(None)); // should be 0.0
+//! println!("All OTM Payoff: {}", all_otm.payoff(None)); // should be 0.0
+//! println!("Call-On-Max Payoff: {}", call_on_max.payoff(None)); // should be 10.0
+//! println!("Call-On-Min Payoff: {}", call_on_min.payoff(None)); // should be 6.0
+//! println!("Put-On-Max Payoff: {}", put_on_max.payoff(None)); // should be 5.0
+//! println!("Put-On-Min Payoff: {}", put_on_min.payoff(None)); // should be 19.0
+//! ```
 
 use super::{OptionStyle, OptionType, RainbowType, RainbowType::*};
 use crate::options::{Instrument, Option};

--- a/src/options/types/rainbow_option.rs
+++ b/src/options/types/rainbow_option.rs
@@ -73,6 +73,7 @@ impl RainbowOption {
     }
 
     /// Calculate the payoff of the Rainbow option.
+    #[rustfmt::skip]
     pub fn payoff(&self) -> f64 {
         let asset_prices: Vec<f64> = self
             .instrument
@@ -83,18 +84,10 @@ impl RainbowOption {
         match self.rainbow_option_type() {
             RainbowType::BestOf => asset_prices.iter().cloned().fold(self.strike, f64::max),
             RainbowType::WorstOf => asset_prices.iter().cloned().fold(self.strike, f64::min),
-            RainbowType::CallOnMax => {
-                (asset_prices.iter().cloned().fold(f64::MIN, f64::max) - self.strike).max(0.0)
-            }
-            RainbowType::CallOnMin => {
-                (asset_prices.iter().cloned().fold(f64::MAX, f64::min) - self.strike).max(0.0)
-            }
-            RainbowType::PutOnMax => {
-                (self.strike - asset_prices.iter().cloned().fold(f64::MIN, f64::max)).max(0.0)
-            }
-            RainbowType::PutOnMin => {
-                (self.strike - asset_prices.iter().cloned().fold(f64::MAX, f64::min)).max(0.0)
-            }
+            RainbowType::CallOnMax => (asset_prices.iter().cloned().fold(f64::MIN, f64::max) - self.strike).max(0.0),
+            RainbowType::CallOnMin => (asset_prices.iter().cloned().fold(f64::MAX, f64::min) - self.strike).max(0.0),
+            RainbowType::PutOnMax => (self.strike - asset_prices.iter().cloned().fold(f64::MIN, f64::max)).max(0.0),
+            RainbowType::PutOnMin => (self.strike - asset_prices.iter().cloned().fold(f64::MAX, f64::min)).max(0.0),
         }
     }
 }

--- a/src/options/types/rainbow_option.rs
+++ b/src/options/types/rainbow_option.rs
@@ -142,16 +142,16 @@ impl Option for RainbowOption {
             PutOnAvg => (self.strike - spot_price).max(0.0),
             AllITM => {
                 if self.instrument().worst_performer().spot > self.strike {
-                    return spot_price;
+                    spot_price
                 } else {
-                    return 0.0;
+                    0.0
                 }
             }
             AllOTM => {
                 if self.instrument().best_performer().spot < self.strike {
-                    return spot_price;
+                    spot_price
                 } else {
-                    return 0.0;
+                    0.0
                 }
             }
         }

--- a/tests/options_pricing.rs
+++ b/tests/options_pricing.rs
@@ -933,6 +933,50 @@ mod instrument_tests {
 
         assert_abs_diff_eq!(price, 100.0, epsilon = 100.0 * 0.01 * 4.0);
     }
+
+    #[test]
+    fn test_assets() {
+        let asset1 = Instrument::new().with_spot(115.0);
+        let asset2 = Instrument::new().with_spot(104.0);
+        let asset3 = Instrument::new().with_spot(86.0);
+
+        let mut instrument = Instrument::new().with_assets(vec![
+            (asset1.clone()),
+            (asset2.clone()),
+            (asset3.clone()),
+        ]);
+
+        assert_abs_diff_eq!(instrument.spot, 101.6666, epsilon = 0.001);
+
+        assert_eq!(instrument.best_performer().spot, asset1.spot);
+        assert_eq!(instrument.worst_performer().spot, asset3.spot);
+        instrument.sort_assets_by_performance();
+        assert_eq!(instrument.assets[0].0.spot, asset1.spot);
+        assert_eq!(instrument.assets[1].0.spot, asset2.spot);
+        assert_eq!(instrument.assets[2].0.spot, asset3.spot);
+    }
+
+    #[test]
+    fn test_weighted_assets() {
+        let asset1 = Instrument::new().with_spot(115.0);
+        let asset2 = Instrument::new().with_spot(104.0);
+        let asset3 = Instrument::new().with_spot(86.0);
+
+        let mut instrument = Instrument::new().with_weighted_assets(vec![
+            (asset1.clone(), 0.5),
+            (asset2.clone(), 0.3),
+            (asset3.clone(), 0.2),
+        ]);
+
+        assert_abs_diff_eq!(instrument.spot, 105.9, epsilon = 0.001);
+
+        assert_eq!(instrument.best_performer().spot, asset1.spot);
+        assert_eq!(instrument.worst_performer().spot, asset3.spot);
+        instrument.sort_assets_by_performance();
+        assert_eq!(instrument.assets[0].0.spot, asset1.spot);
+        assert_eq!(instrument.assets[1].0.spot, asset2.spot);
+        assert_eq!(instrument.assets[2].0.spot, asset3.spot);
+    }
 }
 
 // Option Trait Tests

--- a/tests/options_pricing.rs
+++ b/tests/options_pricing.rs
@@ -937,6 +937,8 @@ mod instrument_tests {
 
 // Option Trait Tests
 mod option_trait_tests {
+    use quantrs::options::RainbowOption;
+
     use super::*;
 
     #[test]
@@ -968,6 +970,40 @@ mod option_trait_tests {
             100.0,
             OptionType::Put,
         );
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::all_itm(
+            Instrument::new().with_spot(100.0).with_assets(vec![]),
+            100.0,
+        );
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::all_otm(
+            Instrument::new()
+                .with_spot(100.0)
+                .with_weighted_assets(vec![]),
+            100.0,
+        );
+        assert_implements_option_trait(&opt);
+        let opt: RainbowOption = RainbowOption::call_on_avg(
+            Instrument::new()
+                .with_spot(100.0)
+                .with_assets(vec![Instrument::new().with_spot(100.0)]),
+            100.0,
+        );
+        assert_implements_option_trait(&opt);
+        let opt: RainbowOption = RainbowOption::put_on_avg(
+            Instrument::new()
+                .with_spot(100.0)
+                .with_weighted_assets(vec![(Instrument::new().with_spot(100.0), 1.0)]),
+            100.0,
+        );
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::call_on_max(Instrument::new().with_spot(100.0), 100.0);
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::put_on_max(Instrument::new().with_spot(100.0), 100.0);
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::call_on_min(Instrument::new().with_spot(100.0), 100.0);
+        assert_implements_option_trait(&opt);
+        let opt = RainbowOption::put_on_min(Instrument::new().with_spot(100.0), 100.0);
         assert_implements_option_trait(&opt);
 
         let model = BlackScholesModel::new(1.0, 0.05, 0.2);


### PR DESCRIPTION
- [x] Implement Rainbow option support for Black Scholes, Binomial and Monte Carlo
- [x] Add new types:
    - `BestOf`: Pays the maximum return of the underlying assets.
    - `WorstOf`: Pays the minimum return of the underlying assets.
    - `CallOnMax`: Pays the difference between the maximum return and the strike price.
    - `CallOnMin`: Pays the difference between the minimum return and the strike price.
    - `PutOnMax`: Pays the difference between the strike price and the maximum return.
    - `PutOnMin`: Pays the difference between the strike price and the minimum return.
    - `CallOnAvg`: Pays the difference between the average return and the strike price.
    - `PutOnAvg`: Pays the difference between the strike price and the average return.
    - `AllITM`: Pays the sum of the returns if all assets are in-the-money.
    - `AllOTM`: Pays the sum of the returns if all assets are out-of-the-money.

Missing tests will be implemented in https://github.com/carlobortolan/quantrs/issues/29.