### PR TITLE
fix: correct 3 option pricing bugs

### DIFF
--- a/src/options/models/binomial_tree.rs
+++ b/src/options/models/binomial_tree.rs
@@ -159,7 +159,7 @@ impl OptionPricing for BinomialTreeModel {
             || matches!(option.style(), OptionStyle::Bermudan)
                 && option.expiration_dates().unwrap().contains(&0.0)
         {
-            option_values[0].max(option.strike() - option.instrument().spot()) // TODO: Change to max(0.0, self.payoff(Some(self.spot)))
+            option_values[0].max(option.payoff(Some(option.instrument().spot())))
         } else {
             option_values[0] // Return the root node value
         }

--- a/src/options/models/black_scholes.rs
+++ b/src/options/models/black_scholes.rs
@@ -409,10 +409,15 @@ impl OptionPricing for BlackScholesModel {
         let normal = Normal::new(0.0, 1.0).unwrap();
         for _ in 0..max_iterations {
             let price = self.price_with_volatility(option, sigma, &normal);
-            let vega = self.vega(option);
+            let bump = 1e-5;
+            let price_up = self.price_with_volatility(option, sigma + bump, &normal);
+            let vega = (price_up - price) / bump;
             let diff = market_price - price;
             if diff.abs() < tolerance {
                 return sigma;
+            }
+            if vega.abs() < 1e-12 {
+                break;
             }
             sigma += diff / vega;
         }

--- a/src/options/models/monte_carlo.rs
+++ b/src/options/models/monte_carlo.rs
@@ -277,9 +277,7 @@ impl MonteCarloModel {
             };
 
             // Now call payoff after the mutable borrow is done
-            sum += (-(self.risk_free_rate - option_clone.instrument().continuous_dividend_yield)
-                * option_clone.time_to_maturity())
-            .exp()
+            sum += (-self.risk_free_rate * option_clone.time_to_maturity()).exp()
                 * option_clone.payoff(Some(avg_price));
         }
 

--- a/tests/options_pricing.rs
+++ b/tests/options_pricing.rs
@@ -733,7 +733,9 @@ mod black_scholes_tests {
         );
         let model = BlackScholesModel::new(0.05, 0.2);
         let iv = model.implied_volatility(&option, 1200.0);
-        assert_abs_diff_eq!(iv, 2947.0381, epsilon = 0.0001);
+        // Market price 1200 is unreachable for this put (max ~95.12), so Newton-Raphson
+        // diverges until vega vanishes. The old test expected 2947 due to using stale vega.
+        assert_abs_diff_eq!(iv, 32.0309, epsilon = 0.0001);
     }
 }
 
@@ -782,7 +784,7 @@ mod binomial_tree_tests {
             let option = AmericanOption::new(instrument, 60.0, 2.0, OptionType::Call);
             let model = BinomialTreeModel::new(0.05, 0.182321557, 2);
 
-            assert_abs_diff_eq!(model.price(&option), 10.0000, epsilon = 0.0001);
+            assert_abs_diff_eq!(model.price(&option), 3.8360, epsilon = 0.0001);
             assert_abs_diff_eq!(model.price(&option.flip()), 10.0000, epsilon = 0.0001);
         }
     }
@@ -808,7 +810,7 @@ mod binomial_tree_tests {
             let option = BermudanOption::new(instrument, 60.0, expiration_dates, OptionType::Call);
             let model = BinomialTreeModel::new(0.05, 0.182321557, 2);
 
-            assert_abs_diff_eq!(model.price(&option), 10.0000, epsilon = 0.0001);
+            assert_abs_diff_eq!(model.price(&option), 3.8360, epsilon = 0.0001);
             assert_abs_diff_eq!(model.price(&option.flip()), 10.0000, epsilon = 0.0001);
         }
     }


### PR DESCRIPTION
## Summary
- **Black-Scholes `implied_volatility`**: Newton-Raphson used `self.vega(option)` which always computed vega at the model's original volatility, not the current iterate `sigma`. Replaced with numerical vega via finite difference `(price(σ+h) - price(σ)) / h`.
- **Binomial tree root node**: Early exercise at root hardcoded put payoff `strike - spot` (as noted in the TODO comment). Replaced with `option.payoff(Some(spot))` which correctly handles both calls and puts.
- **Monte Carlo Asian pricing**: Used `e^(-(r-q)*T)` discount factor, but `log_simulation` already incorporates dividend yield `q` in the drift term. Changed to `e^(-r*T)` for consistency with `simulate_price_paths`.

## Details

### Bug 1: Stale vega in Newton-Raphson (black_scholes.rs)
`self.vega(option)` computes vega using `self.volatility` (the model's initial volatility), not the current Newton-Raphson estimate `sigma`. This means every iteration uses the same vega value, causing the method to take a linear step size rather than properly converging. The fix uses numerical differentiation at the current `sigma`, plus a guard against near-zero vega to prevent division by zero.

### Bug 2: Hardcoded put payoff at root (binomial_tree.rs)
For American/Bermudan options, the root node early exercise check used `option.strike() - option.instrument().spot()`, which is the put payoff regardless of option type. For OTM calls (spot < strike), this incorrectly returned a positive value. The fix uses `option.payoff()` which dispatches correctly based on `OptionType`.

### Bug 3: Double-counted dividend yield (monte_carlo.rs)
In `price_asian`, the discount factor was `e^(-(r-q)*T)`, but the underlying `log_simulation` already subtracts `q` from the drift: `(r - q - 0.5σ²)dt`. The standard `simulate_price_paths` correctly uses `e^(-r*T)`. This fix makes Asian pricing consistent.

## Test plan
- [x] `cargo test` — all 102 option pricing tests pass (+ 12 doc-tests)
- [x] `cargo clippy` — no warnings
- [x] Updated test expectations for binomial tree American/Bermudan OTM calls (previously matched buggy put-payoff behavior)
- [x] Updated IV divergence test expectation (pathological case with unreachable market price)

🤖 Generated with [Claude Code](https://claude.com/claude-code)